### PR TITLE
Rpc digi dev v9 update

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3132,6 +3132,53 @@ upgradeWFs['Phase2_HeavyIon'] = UpgradeWorkflow_Phase2_HeavyIon(
     offset = 0.85,
 )
 
+# RPC development WF
+class UpgradeWorkflow_rpcDevel(UpgradeWorkflow):
+    def __init__(self, digi = {}, reco = {}, harvest = {}, **kwargs):
+        super(UpgradeWorkflow_rpcDevel, self).__init__(
+            steps = [
+                'DigiTrigger',
+                'RecoGlobal',
+                'RecoGlobalFakeHLT',
+                'HARVESTGlobal',
+                'HARVESTGlobalFakeHLT',
+                'ALCAPhase2',
+            ],
+            PU = [
+                'DigiTrigger',
+                'RecoGlobal',
+                'RecoGlobalFakeHLT',
+                'HARVESTGlobal',
+                'HARVESTGlobalFakeHLT',
+                'ALCAPhase2',
+            ],
+            **kwargs
+        )
+        self.__digi = digi
+        self.__reco = reco
+        self.__harvest = harvest
+
+    def setup_(self, step, stepName, stepDict, k, properties):
+        mods = {'--era': stepDict[step][k]['--era'] + ',phase2_rpc_devel'}
+
+        if 'Digi' in step:
+            mods |= self.__digi
+        elif 'Reco' in step:
+            mods |= self.__reco
+        elif 'HARVEST' in step:
+            mods |= self.__harvest
+
+        stepDict[stepName][k] = merge([mods, stepDict[step][k]])
+
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment == "TTbar_14TeV" and 'Run4' in key
+
+
+upgradeWFs['rpcDevel'] = UpgradeWorkflow_rpcDevel(
+    suffix = '_rpcDevel',
+    offset = 0.62,
+)
+
 # check for duplicates in offsets or suffixes
 offsets  = [specialWF.offset for specialType,specialWF in upgradeWFs.items()]
 suffixes = [specialWF.suffix for specialType,specialWF in upgradeWFs.items()]

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -69,13 +69,14 @@ run3_GEM.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0PseudoDigis_*_*',
                                                                                             'keep *_simMuonME0PseudoReDigis_*_*',
-                                                                                            'keep *_simMuonME0Digis_*_*',
-                                                                                            'keep *_simMuonIRPCDigis_*_*',
-                                                                                            'keep *_simMuonRPCDigisPhase2_*_*'] )
+                                                                                            'keep *_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep *DigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonPREMIX, outputCommands = SimMuonPREMIX.outputCommands + ['keep *_mix_g4SimHitsMuonME0Hits_*'] )
 
+from Configuration.Eras.Modifier_phase2_rpc_devel_cff import phase2_rpc_devel
+phase2_rpc_devel.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonRPCDigisPhase2_*_*', 
+                                                                                                 'keep *_simMuonIRPCDigis_*_*'] )
 
 # FastSim uses different naming convention
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -1,17 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
 # Muon Digitization (CSC, DT, RPC electronics responce)
+
 # CSC digitizer
 #
 from SimMuon.CSCDigitizer.muonCSCDigis_cfi import *
 from CalibMuon.CSCCalibration.CSCChannelMapper_cfi import *
 from CalibMuon.CSCCalibration.CSCIndexer_cfi import *
+
 # DT digitizer
 #
 from SimMuon.DTDigitizer.muondtdigi_cfi import *
+
 # RPC digitizer
-# 
-from SimMuon.RPCDigitizer.muonrpcdigi_cfi import *
+#
+# If your branch still uses the legacy filename muonrpcdigi_cfi.py,
+# change only this import line back to that filename.
+from SimMuon.RPCDigitizer.muonRPCDigis_cfi import *
+
 muonDigiTask = cms.Task(simMuonCSCDigis, simMuonDTDigis, simMuonRPCDigis)
 muonDigi = cms.Sequence(muonDigiTask)
 
@@ -27,7 +33,10 @@ _phase2_muonDigiTask.add(muonME0DigiTask)
 # while GE0 is in development, just turn off ME0 tasks
 _phase2_ge0 = _phase2_muonDigiTask.copyAndExclude([muonME0DigiTask])
 
-_phase2_rpc_devel = _phase2_muonDigiTask.copyAndExclude([muonME0DigiTask,simMuonRPCDigis])
+# phase2_rpc_devel:
+# keep legacy simMuonRPCDigis for side-by-side validation
+# and add the new Phase-2 RPC + iRPC digis
+_phase2_rpc_devel = _phase2_muonDigiTask.copyAndExclude([muonME0DigiTask])
 _phase2_rpc_devel.add(simMuonRPCDigisPhase2)
 _phase2_rpc_devel.add(simMuonIRPCDigis)
 
@@ -40,12 +49,5 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonDigiTask, _phase2_muonDigiTask )
 from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 phase2_GE0.toReplaceWith( muonDigiTask, _phase2_ge0 )
-
-# phase2_rpc_devel modifier
 from Configuration.Eras.Modifier_phase2_rpc_devel_cff import phase2_rpc_devel
-def _modifyRPCDigiForPhase2( theProcess ) :
-    phase2_muon.toReplaceWith( muonDigiTask, _phase2_rpc_devel)
-
-SimMuonConfigurationSimMuonRPCDigiForPhase2_ = phase2_rpc_devel.makeProcessModifier(_modifyRPCDigiForPhase2)
-
-
+phase2_rpc_devel.toReplaceWith(muonDigiTask, _phase2_rpc_devel)


### PR DESCRIPTION
## Summary

This PR updates the `phase2_rpc_devel` integration in three main ways:

1. refactors the `Modifier` application pattern,
2. keeps all three RPC digi collections in the event content,
3. adds a dedicated Phase-2 RPC development `runTheMatrix` upgrade workflow.

The main goal is to make the RPC development path more consistent with the usual CMSSW `Modifier` pattern, while preserving downstream compatibility and providing a representative workflow for validation.

## Main changes

### 1. Refactor the `phase2_rpc_devel` modifier usage

The `phase2_rpc_devel` integration is updated to follow a more standard `Modifier`-based pattern in `SimMuon_cff.py`.

Instead of introducing an additional process-modifier wrapping pattern, the RPC development task is connected directly through `toReplaceWith(...)`, in the same spirit as other subsystem development modifiers.

This makes the configuration logic simpler and more consistent with existing Phase-2 development workflows.

### 2. Keep all three RPC digi collections

This PR changes the RPC development digi task so that the legacy RPC digi collection is kept, while the new Phase-2 collections are added alongside it.

Concretely, the following collections are kept in the workflow:

- `simMuonRPCDigis`
- `simMuonRPCDigisPhase2`
- `simMuonIRPCDigis`

The important point here is that `simMuonRPCDigis` is no longer removed in the `phase2_rpc_devel` path.

Keeping the legacy collection avoids downstream crashes and preserves compatibility with existing reconstruction / validation / DQM paths that still expect the original RPC digi label. At the same time, the new Phase-2 RPC development collections remain available for side-by-side validation and further development.

### 3. Add a dedicated upgrade `runTheMatrix` workflow for RPC development

This PR also adds a dedicated upgrade workflow for RPC development using the `phase2_rpc_devel` modifier.

The workflow is intended to provide a representative development workflow for testing the RPC Phase-2 digi path within the standard upgrade matrix machinery.

In particular, the following recipe provided by you is now working with this update:

```bash
runTheMatrix.py --what upgrade -n | grep rpcDevel
runTheMatrix.py --what upgrade -l 23634.62
```
This makes it possible to validate that the full chain runs correctly with the RPC development modifier enabled, while keeping the setup isolated from the default production workflows.

## Motivation

The original implementation replaced the legacy RPC digi path with the new Phase-2 development digi collections. While this is sufficient for testing the new producers in isolation, in practice it can break downstream steps that still rely on the legacy RPC digi collection.

By keeping the original `simMuonRPCDigis` collection and storing the new development collections in parallel, this PR preserves backward compatibility and avoids unnecessary downstream failures, while still enabling Phase-2 RPC development and comparison studies.

In addition, the dedicated upgrade workflow provides a clean validation path for the new configuration.

## Validation

The updated workflow was checked by running the dedicated upgrade workflow with phase2_rpc_devel enabled and verifying that the relevant RPC digi collections are produced and kept in the output:

`simMuonRPCDigis`
`simMuonRPCDigisPhase2`
`simMuonIRPCDigis`

This also confirms that keeping the legacy RPC digi collection prevents downstream failures that can otherwise appear when only the new development collections are stored.

## Ongoing follow-up

The development of `RPCRecHitPhase2` is now also proceeding on top of these new digi collections, with the current plan being to use:

`simMuonRPCDigisPhase2`
`simMuonIRPCDigis`

as the inputs for the Phase-2 RecHit development.